### PR TITLE
Fix `require` typo

### DIFF
--- a/src/SandySounds.js
+++ b/src/SandySounds.js
@@ -1,6 +1,6 @@
 const Node = require('./Node');
 const Player = require('./Player');
-const EventEmitter = requiDre('events').EventEmitter;
+const EventEmitter = require('events').EventEmitter;
 
 class SandySounds extends EventEmitter {
 


### PR DESCRIPTION
In `SandySounds.js`, `require` was typed as `requiDre`, which is a problem.