### PR TITLE
Fix Array.from(...) is not a function error

### DIFF
--- a/src/versions/v1/SandySounds.js
+++ b/src/versions/v1/SandySounds.js
@@ -90,7 +90,7 @@ class SandySounds extends EventEmitter {
 
 
     onDisconnect(node, msg) {
-        let players = Array.from(this.players.values())(player => player.node.host === node.host);
+        let players = Array.from(this.players.values()).filter(player => player.node.host === node.host);
         for (let player of players) {
             this.queueFailover(this.switchNode.bind(this, player, true));
         }

--- a/src/versions/v2/SandySounds.js
+++ b/src/versions/v2/SandySounds.js
@@ -90,7 +90,7 @@ class SandySounds extends EventEmitter {
 
 
     onDisconnect(node, msg) {
-        let players = Array.from(this.nodes.values())(player => player.node.host === node.host);
+        let players = Array.from(this.nodes.values()).filter(player => player.node.host === node.host);
         for (let player of players) {
             this.queueFailover(this.switchNode.bind(this, player, true));
         }


### PR DESCRIPTION
This code replaces `Array.from(...)(...)` with `Array.from(...).filter(...)`, fixing the above error.