### PR TITLE
Squash all the bugs!

### DIFF
--- a/src/versions/v1/Node.js
+++ b/src/versions/v1/Node.js
@@ -32,6 +32,7 @@ class Node extends EventEmitter {
         this.port = options.port || 80;
         this.url = `${this.host}:${this.port}`;
         this.address = `ws://${this.host}:${this.port}`;
+        this.restAddress = `http://${this.host}:${options.restPort}`;
         this.region = options.region || null;
         this.userId = options.userId;
         this.numShards = options.numShards;
@@ -61,9 +62,11 @@ class Node extends EventEmitter {
         });
 
         this.rest = axios.create({
-            baseURL: this.url,
+            baseURL: this.restAddress,
             headers: {
-                'Authorization': this.password
+                common: {
+                    "Authorization": this.password
+                }
             }
         });
 
@@ -181,11 +184,8 @@ class Node extends EventEmitter {
     }
 
     async resolveTrack(identifier) {
-        return this.rest.get('/loadtracks', {
-            params: {
-                identifier: identifier
-            }
-        });
+        let response = await this.rest.get(`/loadtracks?identifier=${identifier}`);
+        return response.data;
     }
 }
 

--- a/src/versions/v1/SandySounds.js
+++ b/src/versions/v1/SandySounds.js
@@ -43,7 +43,6 @@ class SandySounds extends EventEmitter {
             password: options.password,
         });
 
-        node.connect();
         node.on('error', this.onError.bind(this, node));
         node.on('disconnect', this.onDisconnect.bind(this, node));
         node.on('message', this.onMessage.bind(this, node));

--- a/src/versions/v1/SandySounds.js
+++ b/src/versions/v1/SandySounds.js
@@ -310,7 +310,7 @@ class SandySounds extends EventEmitter {
     }
 
 
-    async voiceServerUpdate(data, session_id) {
+    async voiceServerUpdate(data) {
         if (this.pendingGuilds[data.guild_id] && this.pendingGuilds[data.guild_id].timeout) {
             clearTimeout(this.pendingGuilds[data.guild_id].timeout);
             this.pendingGuilds[data.guild_id].timeout = null;
@@ -325,7 +325,7 @@ class SandySounds extends EventEmitter {
             player = this.pendingGuilds[data.guild_id].player;
 
             if (player) {
-                player.sessionId = session_id;
+                player.sessionId = data.session_id;
                 player.hostname = this.pendingGuilds[data.guild_id].hostname;
                 player.node = this.pendingGuilds[data.guild_id].node;
                 player.event = data;
@@ -334,7 +334,7 @@ class SandySounds extends EventEmitter {
                 player = new Player(data.guild_id, {
                     shardID: data.shard_id,
                     guildId: data.guild_id,
-                    sessionId: session_id,
+                    sessionId: data.session_id,
                     channelId: this.pendingGuilds[data.guild_id].channelId,
                     hostname: this.pendingGuilds[data.guild_id].hostname,
                     node: this.pendingGuilds[data.guild_id].node,
@@ -346,7 +346,7 @@ class SandySounds extends EventEmitter {
             }
 
             player.connect({
-                sessionId: session_id,
+                sessionId: data.session_id,
                 guildId: data.guild_id,
                 channelId: this.pendingGuilds[data.guild_id].channelId,
                 event: {


### PR DESCRIPTION
This pull request should leave SandySounds in **pristine condition.** In other works, it'll magically work now! :unicorn:

Here's a summary of the bug fixes this brings:
* Added a `restPort` property to `Node`
* Fixed `../regions` error
* ~~Added a `session_id` argument~~ (removed)
* And more!